### PR TITLE
Fix for a colorbar handle bug in recent (>R2014B) versions of MATLAB

### DIFF
--- a/som/som_show.m
+++ b/som/som_show.m
@@ -490,10 +490,9 @@ for i=1:n,                         % main loop
   
   %%% Draw colorbars if they are turned on and the plane is umat or c-plane
 
-  if General.comp(i)> -1 && ~strcmp(General.colorbardir,'none'),
-    h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
-  else
-    h_colorbar(i,1)=-1;
+  h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+  if General.comp(i)< 0 || strcmp(General.colorbardir,'none'),
+    h_colorbar(i,1).Visible='off';
     General.comp(i)=-1;
   end
 end         %% main loop ends

--- a/som/som_show.m
+++ b/som/som_show.m
@@ -490,9 +490,21 @@ for i=1:n,                         % main loop
   
   %%% Draw colorbars if they are turned on and the plane is umat or c-plane
 
-  h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
-  if General.comp(i)< 0 || strcmp(General.colorbardir,'none'),
-    h_colorbar(i,1).Visible='off';
+  if General.comp(i)> -1 && ~strcmp(General.colorbardir,'none'),
+    h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+  else
+    %COMPATIBILITY HACK: This if...else... structure fixes a compatibility
+    %problem. In versions of MATLAB prior to 2014b colorbars returned a
+    %numeric handle. From 2014b onwards they return a structure, and they
+    %break backwards compatibility. At some point the numeric compatibility
+    %should be dropped, but for the time being this is a necessary small hack.
+    if verLessThan('matlab','8.4')
+        h_colorbar(i,1)=-1;
+    else
+        h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+        h_colorbar(i,1).Visible='off';
+    end
+    %END OF COMPATIBILITY HACK
     General.comp(i)=-1;
   end
 end         %% main loop ends


### PR DESCRIPTION
The bug prevents the use of som_demo2 onwards, as they all make use of colorbar hiding. Recent versions of MATLAB changed the way they interpret colorbars and no longer accept 'doubles'. This fix creates it anyway and makes it invisible.