### PR TITLE
Don't overwrite sNorm

### DIFF
--- a/som/som_norm_variable.m
+++ b/som/som_norm_variable.m
@@ -245,16 +245,17 @@ if ischar(method)
   if any(strcmp(method,{'var','range','log','logistic','histD','histC'})), 
     sNorm = som_set('som_norm','method',method);
   else 
-    method = cellstr(method); 
+    method = cellstr(method);
   end
-end
-if iscell(method), 
+elseif iscell(method),
   if length(method)==1 && isstruct(method{1}), sNorm = method{1}; 
   else
-    if length(method)==1 || isempty(method{2}), method{2} = 'x'; end
+    if length(method)==1 || isempty(method{2}), 
+      method{2} = 'x'; 
+    end
     sNorm = som_set('som_norm','method','eval','params',method);
   end
-else 
+else
   sNorm = method; 
 end
 


### PR DESCRIPTION
When argument 'method' was a char variable, the argument checking mechanism was initialising sNorm correctly, then overwriting the value of the initialised sNorm with the value of 'method'. The initialisation was correct, and should not get overwritten. 

When the modification has been made, calling som_norm_variable(x, 'var', 'do') will return a normalised x as expected. Unfixed, calling som_norm_variable(x, 'var', 'do') will result in an error:

Struct contents reference from a non-struct
array object.

Error in som_norm_variable (line 271)
     (strcmp(operation,'do') &&
     strcmp(sNorm(i).status,'uninit')),