### PR TITLE
Use 'any' to allow checking of bins vector

### DIFF
--- a/som/som_stats.m
+++ b/som/som_stats.m
@@ -171,7 +171,7 @@ function sH = som_hist(x,bins,sN)
 
     binlabels  = []; 
     binlabels2 = []; 
-    if nargin<2 || isempty(bins) || isnan(bins), 
+    if nargin<2 || isempty(bins) || any(isnan(bins)), 
         bins = linspace(min(x),max(x),10);    
     end
     if isstruct(bins), 


### PR DESCRIPTION
The value of "bins" is a vector of histogram bin centers. For a correctly formed "bins" that is a vector with multiple values, isnan(bins) returns a vector of boolean values that can't be compared using ||, throwing an error.

To fix this error, I'd remove the isnan check, but I'm assuming that it's there for a reason.
By wrapping it with any() the value is false if any bins contain a NaN, but true if "bins" is a vector, as expected.