### PR TITLE
Removed unnecessary check

### DIFF
--- a/som/som_train_struct.m
+++ b/som/som_train_struct.m
@@ -240,7 +240,7 @@ while i<=length(varargin),
 	  sTprev = varargin{i}.trainhist(end); 
 	  msize = varargin{i}.topol.msize; 
 	end
-	if ~isempty(varargin{i}.neigh) && isempty(sTrain.neigh), 
+	if ~isempty(varargin{i}.neigh) 
 	  sTrain.neigh = varargin{i}.neigh; 
 	end
 	if ~isempty(varargin{i}.mask) && isempty(sTrain.mask),  


### PR DESCRIPTION
Removed an unnecessary check which blocks the user from selecting neighborhood function other than Gaussian.
The neighborhood function is populated at initialization which means that if another function selected (either from another map or as input argument) it will be discarded.