### PR TITLE
Octave compatibility

### DIFF
--- a/dijkstra/dijkstraKay.m
+++ b/dijkstra/dijkstraKay.m
@@ -110,6 +110,6 @@ for i = 1:length(s)
    D(i,:) = Di(t)';
 end
 
-if nargout > 1 & length(s) == 1 & length(t) == 1
+if nargout > 1 && length(s) == 1 && length(t) == 1
    P = pred2path(P,s,t);
 end

--- a/dijkstra/dijkstraKay.m
+++ b/dijkstra/dijkstraKay.m
@@ -1,4 +1,4 @@
-function [D,P] = dijkstra(A,s,t)
+function [D,P] = dijkstraKay(A,s,t)
 %DIJK Shortest paths from nodes 's' to nodes 't' using Dijkstra algorithm.
 % [D,p] = dijk(A,s,t)
 %     A = n x n node-node weighted adjacency matrix of arc lengths

--- a/som/MATLABverLessThan.m
+++ b/som/MATLABverLessThan.m
@@ -1,0 +1,12 @@
+
+function result = MATLABverLessThan(version)
+
+  % verLessThan() not currently (September 2018) available on Octave
+
+  try
+    result = verLessThan('matlab', version);
+  catch
+    result = true;
+  end
+
+end

--- a/som/som_recolorbar.m
+++ b/som/som_recolorbar.m
@@ -158,7 +158,7 @@ end
 
 [handles, msg, lattice, msize, dim, normalization, comps]= ...
     vis_som_show_data(p, gcf);
-error(msg);                                       
+error(strcat(msg));
 
 if nargin < 2 || isempty(ticks)                   % default tick mode is 'auto'
   ticks = 'auto';

--- a/som/som_recolorbar.m
+++ b/som/som_recolorbar.m
@@ -300,7 +300,7 @@ for i=1:length(handles),                   % MAIN LOOP BEGINS
       if strcmp(scale,'normalized'),   ch(1)='n'; end
       if strcmp(scale,'denormalized'), ch(1)='d'; end
       if strcmp(labels,'explicit'),    ch(2)='u'; end
-      if verLessThan('matlab', '8.4')
+      if MATLABverLessThan('8.4')
           mem_axes = gca();
           axes(h_(i));
           xlabel(ch);

--- a/som/som_show.m
+++ b/som/som_show.m
@@ -502,7 +502,7 @@ for i=1:n,                         % main loop
     %numeric handle. From 2014b onwards they return a structure, and they
     %break backwards compatibility. At some point the numeric compatibility
     %should be dropped, but for the time being this is a necessary small hack.
-    if verLessThan('matlab','8.4')
+    if MATLABverLessThan('8.4')
         h_colorbar(i,1)=-1;
     else
         try

--- a/som/som_show.m
+++ b/som/som_show.m
@@ -491,7 +491,11 @@ for i=1:n,                         % main loop
   %%% Draw colorbars if they are turned on and the plane is umat or c-plane
 
   if General.comp(i)> -1 && ~strcmp(General.colorbardir,'none'),
-    h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+    try
+      h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+    catch
+      h_colorbar(i,1)=colorbar();           % colorbars
+    end
   else
     %COMPATIBILITY HACK: This if...else... structure fixes a compatibility
     %problem. In versions of MATLAB prior to 2014b colorbars returned a
@@ -501,7 +505,11 @@ for i=1:n,                         % main loop
     if verLessThan('matlab','8.4')
         h_colorbar(i,1)=-1;
     else
-        h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+        try
+          h_colorbar(i,1)=colorbar(General.colorbardir);           % colorbars
+        catch
+          h_colorbar(i,1)=colorbar();           % colorbars
+        end
         h_colorbar(i,1).Visible='off';
     end
     %END OF COMPATIBILITY HACK


### PR DESCRIPTION
This fork lets the standard "iris.data" example run under Octave.
